### PR TITLE
docs: use terraform built-in GitHub module source

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains terraform module with example opentelemetry-collector d
 
 ```
 module "otel_collector" {
-  source = "modules/datadog-opentelemetry-collector"
+  source = "github.com/saleor/datadog-opentelemetry-collector"
 
   name = "opentelemetry"
 


### PR DESCRIPTION
This changes the README.md to tell users to install the module using the [GitHub module source] of Terraform instead of requiring them to clone the git repository.

This simplifies the user-experience (installation & maintenance) and makes it more consistent with how developers typically use external terraform modules.

[GitHub module source]: https://developer.hashicorp.com/terraform/language/modules/sources#github